### PR TITLE
Fix dependency versions and lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext .ts,.vue",
+    "lint": "eslint .",
     "format": "prettier --write ."
   },
   "dependencies": {
@@ -16,7 +16,7 @@
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.3",
     "papaparse": "^5.4.1",
-    "parquetjs-lite": "^0.13.0"
+    "parquetjs-lite": "^0.8.7"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
@@ -26,7 +26,7 @@
     "vite": "^5.2.7",
     "eslint": "^8.57.0",
     "eslint-plugin-vue": "^9.23.0",
-    "@vue/eslint-config-typescript": "^13.1.0",
+    "@vue/eslint-config-typescript": "^13.0.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.1",
     "prettier": "^3.2.5"


### PR DESCRIPTION
## Summary
- update parquetjs-lite to 0.8.7 (latest available)
- pin @vue/eslint-config-typescript to 13.x (works with eslint v8)
- simplify lint script for the flat config

## Testing
- `npm run lint`
- `npm run build` *(after `npm install`)*

------
https://chatgpt.com/codex/tasks/task_e_6862d64925f8832182004ea151640c3d