### PR TITLE
Add product cache and Vercel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ Projeto base em Vue 3 + Vite para catálogo de acessórios pet.
 npm install
 npm run dev
 ```
+
+## Deploy no Vercel
+
+Execute o build e faça o upload da pasta `dist/` para o Vercel:
+
+```bash
+npm run build
+```
+
+Arquivos de dados devem ficar em `public/data/`. O arquivo `vercel.json` já
+configura cabeçalhos `Cache-Control` para esta pasta, permitindo que o conteúdo
+fique armazenado na CDN por 24 horas.

--- a/src/pages/Home/index.vue
+++ b/src/pages/Home/index.vue
@@ -2,7 +2,11 @@
   <div>
     <h1>Catálogo</h1>
     <div class="row g-3">
-      <div v-for="p in displayed" :key="p.id" class="col-sm-6 col-md-4 col-lg-3">
+      <div
+        v-for="p in displayed"
+        :key="p.id"
+        class="col-sm-6 col-md-4 col-lg-3"
+      >
         <div class="card h-100">
           <img :src="p.image" class="card-img-top" />
           <div class="card-body">
@@ -17,19 +21,25 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted } from 'vue'
 import { useProductStore } from '@/stores/product'
 import { useCartStore } from '@/stores/cart'
 import { priceByRole } from '@/utils/priceByRole'
 import { useAuthStore } from '@/stores/auth'
+import { loadProducts } from '@/services/api'
 import type { Product } from '@/types'
 
 const productStore = useProductStore()
 const cartStore = useCartStore()
 const authStore = useAuthStore()
 const displayed = computed(() => {
-  if (!authStore.user || authStore.user.role === 'consumer') return productStore.products
+  if (!authStore.user || authStore.user.role === 'consumer')
+    return productStore.products
   return productStore.products.slice(0, 10)
+})
+
+onMounted(() => {
+  loadProducts('/data/produtos.json')
 })
 
 function add(p: Product) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -32,6 +32,9 @@ async function parseParquet(path: string): Promise<Product[]> {
 
 export async function loadProducts(file: File | string): Promise<void> {
   const store = useProductStore()
+  store.load()
+  if (store.products.length > 0) return
+
   const name = typeof file === 'string' ? file : file.name
   const ext = name.split('.').pop()
   let data: Product[] = []

--- a/src/stores/product.ts
+++ b/src/stores/product.ts
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia'
 import type { Product } from '@/types'
 
+const STORAGE_KEY = 'products'
+
 export const useProductStore = defineStore('product', {
   state: () => ({
     products: [] as Product[],
@@ -8,6 +10,24 @@ export const useProductStore = defineStore('product', {
   actions: {
     set(products: Product[]) {
       this.products = products
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ products, timestamp: Date.now() })
+      )
+    },
+    load() {
+      const data = localStorage.getItem(STORAGE_KEY)
+      if (data) {
+        try {
+          const { products } = JSON.parse(data) as {
+            products: Product[]
+            timestamp: number
+          }
+          this.products = products
+        } catch {
+          // ignore parse errors
+        }
+      }
     },
   },
 })

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "headers": [
+    {
+      "source": "/data/(.*)",
+      "headers": [{ "key": "Cache-Control", "value": "public, max-age=86400" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- save and load products from localStorage
- avoid reloading if cached products exist
- load products on the Home page
- add `public/data` folder with cache headers in `vercel.json`
- document Vercel deployment steps

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6862de808ef48321bf36113aced9501e