### PR TITLE
Implement secure login and serverless parquet loader

### DIFF
--- a/api/loadParquet.ts
+++ b/api/loadParquet.ts
@@ -1,0 +1,26 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import parquet from 'parquetjs-lite'
+import path from 'path'
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const file = req.query.file as string | undefined
+  if (!file) {
+    res.status(400).json({ error: 'missing file' })
+    return
+  }
+  const filePath = path.join(process.cwd(), 'public', file)
+  try {
+    const reader = await parquet.ParquetReader.openFile(filePath)
+    const cursor = reader.getCursor()
+    const rows: any[] = []
+    let row = await cursor.next()
+    while (row) {
+      rows.push(row)
+      row = await cursor.next()
+    }
+    await reader.close()
+    res.status(200).json(rows)
+  } catch (err) {
+    res.status(500).json({ error: 'failed to read parquet' })
+  }
+}

--- a/api/login.ts
+++ b/api/login.ts
@@ -1,0 +1,42 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import jwt from 'jsonwebtoken'
+import cookie from 'cookie'
+
+interface User {
+  id: number
+  name: string
+  password: string
+  role: 'consumer' | 'shop' | 'distributor' | 'admin'
+}
+
+const users: User[] = [
+  { id: 1, name: 'admin', password: 'admin', role: 'admin' },
+  { id: 2, name: 'user', password: 'user', role: 'consumer' },
+]
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret'
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).send('Method Not Allowed')
+    return
+  }
+  const { name, password } = req.body || {}
+  const user = users.find((u) => u.name === name && u.password === password)
+  if (!user) {
+    res.status(401).json({ error: 'Invalid credentials' })
+    return
+  }
+  const token = jwt.sign({ id: user.id, name: user.name, role: user.role }, JWT_SECRET, { expiresIn: '1d' })
+  res.setHeader(
+    'Set-Cookie',
+    cookie.serialize('token', token, {
+      httpOnly: true,
+      path: '/',
+      maxAge: 60 * 60 * 24,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+    })
+  )
+  res.status(200).json({ user: { id: user.id, name: user.name, role: user.role } })
+}

--- a/api/logout.ts
+++ b/api/logout.ts
@@ -1,0 +1,18 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import cookie from 'cookie'
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).send('Method Not Allowed')
+    return
+  }
+  res.setHeader(
+    'Set-Cookie',
+    cookie.serialize('token', '', {
+      httpOnly: true,
+      path: '/',
+      maxAge: 0,
+    })
+  )
+  res.status(204).end()
+}

--- a/api/me.ts
+++ b/api/me.ts
@@ -1,0 +1,19 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import jwt from 'jsonwebtoken'
+import cookie from 'cookie'
+
+const JWT_SECRET = process.env.JWT_SECRET || 'secret'
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  const { token } = cookie.parse(req.headers.cookie || '')
+  if (!token) {
+    res.status(401).end()
+    return
+  }
+  try {
+    const payload = jwt.verify(token, JWT_SECRET) as { id: number; name: string; role: string }
+    res.status(200).json({ user: { id: payload.id, name: payload.name, role: payload.role } })
+  } catch {
+    res.status(401).end()
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,25 +10,27 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "vue": "^3.4.21",
-    "vue-router": "^4.2.5",
-    "pinia": "^2.1.7",
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.3",
+    "cookie": "^1.0.2",
+    "jsonwebtoken": "^9.0.2",
     "papaparse": "^5.4.1",
-    "parquetjs-lite": "^0.8.7"
+    "parquetjs-lite": "^0.8.7",
+    "pinia": "^2.1.7",
+    "vue": "^3.4.21",
+    "vue-router": "^4.2.5"
   },
   "devDependencies": {
     "@types/node": "^20.11.30",
     "@vitejs/plugin-vue": "^5.0.4",
-    "sass": "^1.73.0",
-    "typescript": "~5.4.3",
-    "vite": "^5.2.7",
-    "eslint": "^8.57.0",
-    "eslint-plugin-vue": "^9.23.0",
     "@vue/eslint-config-typescript": "^13.0.0",
+    "eslint": "^8.57.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.29.1",
-    "prettier": "^3.2.5"
+    "eslint-plugin-vue": "^9.23.0",
+    "prettier": "^3.2.5",
+    "sass": "^1.73.0",
+    "typescript": "~5.4.3",
+    "vite": "^5.2.7"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,9 +7,14 @@ import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap-icons/font/bootstrap-icons.css'
 import './design-system/index.scss'
 
-const app = createApp(App)
-const pinia = createPinia()
-app.use(pinia)
-useAuthStore(pinia).load()
-app.use(router)
-app.mount('#app')
+async function bootstrap() {
+  const app = createApp(App)
+  const pinia = createPinia()
+  app.use(pinia)
+  await useAuthStore(pinia).load()
+  app.use(router)
+  await router.isReady()
+  app.mount('#app')
+}
+
+bootstrap()

--- a/src/pages/Login/index.vue
+++ b/src/pages/Login/index.vue
@@ -6,12 +6,7 @@
         <input v-model="name" type="text" class="form-control" placeholder="Nome" required />
       </div>
       <div class="mb-3">
-        <select v-model="role" class="form-select">
-          <option value="consumer">Consumidor</option>
-          <option value="shop">Lojista</option>
-          <option value="distributor">Distribuidora</option>
-          <option value="admin">Admin</option>
-        </select>
+        <input v-model="password" type="password" class="form-control" placeholder="Senha" required />
       </div>
       <button class="btn btn-primary" type="submit">Entrar</button>
     </form>
@@ -20,14 +15,14 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { useAuthStore, type User } from '@/stores/auth'
+import { useAuthStore } from '@/stores/auth'
 import { useRouter } from 'vue-router'
 const auth = useAuthStore()
 const router = useRouter()
 const name = ref('')
-const role = ref<User['role']>('consumer')
-function submit() {
-  auth.login({ id: 1, name: name.value, role: role.value }, 'token')
+const password = ref('')
+async function submit() {
+  await auth.login(name.value, password.value)
   router.push('/')
 }
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,8 +24,9 @@ const router = createRouter({
   routes,
 })
 
-router.beforeEach((to) => {
+router.beforeEach(async (to) => {
   const auth = useAuthStore()
+  if (!auth.user) await auth.load()
   if (to.meta.requiresAuth && !auth.user) return { name: 'login' }
   if (to.meta.roles && !to.meta.roles.includes(auth.user?.role ?? '')) return { name: 'home' }
   if (to.meta.guestOnly && auth.user) return { name: 'home' }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,5 +1,4 @@
 import Papa from 'papaparse'
-import parquet from 'parquetjs-lite'
 import type { Product } from '@/types'
 import { useProductStore } from '@/stores/product'
 
@@ -18,16 +17,9 @@ async function parseJSON(path: string): Promise<Product[]> {
 }
 
 async function parseParquet(path: string): Promise<Product[]> {
-  const reader = await parquet.ParquetReader.openFile(path)
-  const cursor = reader.getCursor()
-  const rows: Product[] = []
-  let row = await cursor.next()
-  while (row) {
-    rows.push(row as Product)
-    row = await cursor.next()
-  }
-  await reader.close()
-  return rows
+  const res = await fetch(`/api/loadParquet?file=${encodeURIComponent(path.replace(/^\/+/, ''))}`)
+  if (!res.ok) throw new Error('Failed to load parquet')
+  return res.json()
 }
 
 export async function loadProducts(file: File | string): Promise<void> {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -6,45 +6,37 @@ export interface User {
   role: 'consumer' | 'shop' | 'distributor' | 'admin'
 }
 
-const STORAGE_KEY = 'auth'
-
 export const useAuthStore = defineStore('auth', {
   state: () => ({
     user: null as User | null,
-    token: '',
     expires: 0,
   }),
   actions: {
-    login(user: User, token: string) {
-      this.user = user
-      this.token = token
+    async login(name: string, password: string) {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, password }),
+      })
+      if (!res.ok) throw new Error('Invalid credentials')
+      const data = await res.json()
+      this.user = data.user
       this.expires = Date.now() + 24 * 60 * 60 * 1000
-      localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify({ user: this.user, token: this.token, expires: this.expires })
-      )
     },
-    load() {
-      const data = localStorage.getItem(STORAGE_KEY)
-      if (!data) return
-      const { user, token, expires } = JSON.parse(data) as {
-        user: User
-        token: string
-        expires: number
-      }
-      if (expires > Date.now()) {
-        this.user = user
-        this.token = token
-        this.expires = expires
-      } else {
-        localStorage.removeItem(STORAGE_KEY)
+    async load() {
+      try {
+        const res = await fetch('/api/me')
+        if (!res.ok) return
+        const data = await res.json()
+        this.user = data.user
+      } catch {
+        // ignore network errors
       }
     },
-    logout() {
+    async logout() {
+      await fetch('/api/logout', { method: 'POST' })
       this.user = null
-      this.token = ''
       this.expires = 0
-      localStorage.removeItem(STORAGE_KEY)
     },
   },
 })

--- a/src/stores/cart.ts
+++ b/src/stores/cart.ts
@@ -25,7 +25,13 @@ export const useCartStore = defineStore('cart', {
     },
     load() {
       const data = localStorage.getItem(STORAGE_KEY)
-      if (data) this.items = JSON.parse(data)
+      if (!data) return
+      try {
+        this.items = JSON.parse(data)
+      } catch {
+        localStorage.removeItem(STORAGE_KEY)
+        this.items = []
+      }
     },
     persist() {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(this.items))

--- a/src/utils/parquet.ts
+++ b/src/utils/parquet.ts
@@ -1,14 +1,5 @@
-import parquet from 'parquetjs-lite'
-
 export async function parquetToJson<T>(path: string): Promise<T[]> {
-  const reader = await parquet.ParquetReader.openFile(path)
-  const cursor = reader.getCursor()
-  const rows: T[] = []
-  let row = await cursor.next()
-  while (row) {
-    rows.push(row as T)
-    row = await cursor.next()
-  }
-  await reader.close()
-  return rows
+  const res = await fetch(`/api/loadParquet?file=${encodeURIComponent(path.replace(/^\/+/, ''))}`)
+  if (!res.ok) throw new Error('Failed to load parquet')
+  return res.json()
 }


### PR DESCRIPTION
## Summary
- add serverless API endpoints for login/logout/me and Parquet parsing
- move authentication to HTTP-only cookies
- update login page to use new API
- load user from cookie and protect routes
- safely parse cart data from localStorage
- parse Parquet files on the server

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6862ea1dd5b083219c1405f669d88544