### PR TITLE
Implement header cart panel

### DIFF
--- a/src/components/shared/CartPanel/index.ts
+++ b/src/components/shared/CartPanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from './index.vue'

--- a/src/components/shared/CartPanel/index.vue
+++ b/src/components/shared/CartPanel/index.vue
@@ -1,0 +1,45 @@
+<template>
+  <div :class="panelClasses">
+    <h5 class="mb-2">Carrinho</h5>
+    <div v-if="cart.items.length === 0">Vazio</div>
+    <ul v-else class="list-group mb-2">
+      <li
+        v-for="i in cart.items"
+        :key="i.product.id"
+        class="list-group-item d-flex justify-content-between align-items-center"
+      >
+        <span>{{ i.product.name }} (x{{ i.quantity }})</span>
+        <button class="btn btn-sm btn-danger" @click="cart.remove(i.product.id)">
+          Remover
+        </button>
+      </li>
+    </ul>
+    <div class="form-check">
+      <input
+        class="form-check-input"
+        type="checkbox"
+        id="cartFixedCheck"
+        v-model="cart.fixed"
+        @change="cart.persist()"
+      />
+      <label class="form-check-label" for="cartFixedCheck">
+        Fixo
+      </label>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useCartStore } from '@/stores/cart'
+
+const cart = useCartStore()
+cart.load()
+
+const panelClasses = computed(() => [
+  'cart-panel',
+  cart.fixed ? 'position-fixed' : 'position-absolute',
+])
+</script>
+
+<style scoped src="./styles.scss"></style>

--- a/src/components/shared/CartPanel/styles.scss
+++ b/src/components/shared/CartPanel/styles.scss
@@ -1,0 +1,9 @@
+.cart-panel {
+  right: 10px;
+  top: 70px;
+  width: 250px;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  z-index: 1050;
+}

--- a/src/components/shared/HeaderBar/index.vue
+++ b/src/components/shared/HeaderBar/index.vue
@@ -11,7 +11,12 @@
           <li class="nav-item"><router-link class="nav-link" to="/freight">Frete</router-link></li>
         </ul>
         <ThemeToggle />
-        <router-link class="btn btn-outline-primary ms-2" to="/cart">Carrinho</router-link>
+        <div class="position-relative ms-2">
+          <button class="btn btn-outline-primary" @click="togglePanel">
+            <i class="bi bi-cart"></i>
+          </button>
+          <CartPanel v-if="cart.visible || cart.fixed" />
+        </div>
       </div>
     </div>
   </header>
@@ -19,9 +24,19 @@
 
 <script setup lang="ts">
 import ThemeToggle from '@/components/shared/ThemeToggle/index.vue'
+import CartPanel from "@/components/shared/CartPanel/index.vue"
+import { useCartStore } from "@/stores/cart"
+
+const cart = useCartStore()
+cart.load()
+
+function togglePanel() {
+  cart.visible = !cart.visible
+}
 </script>
 
 <style scoped>
+.navbar { position: relative; }
 .navbar-brand {
   font-weight: bold;
 }

--- a/src/stores/cart.ts
+++ b/src/stores/cart.ts
@@ -6,11 +6,14 @@ export interface CartItem {
   quantity: number
 }
 
-const STORAGE_KEY = 'cart'
+const STORAGE_KEY = 'cart_items'
+const STORAGE_FIXED_KEY = 'cart_fixed'
 
 export const useCartStore = defineStore('cart', {
   state: () => ({
     items: [] as CartItem[],
+    fixed: false,
+    visible: false,
   }),
   actions: {
     add(product: Product) {
@@ -24,17 +27,27 @@ export const useCartStore = defineStore('cart', {
       this.persist()
     },
     load() {
-      const data = localStorage.getItem(STORAGE_KEY)
-      if (!data) return
-      try {
-        this.items = JSON.parse(data)
-      } catch {
-        localStorage.removeItem(STORAGE_KEY)
-        this.items = []
+      const items = localStorage.getItem(STORAGE_KEY)
+      if (items) {
+        try {
+          this.items = JSON.parse(items)
+        } catch {
+          localStorage.removeItem(STORAGE_KEY)
+          this.items = []
+        }
+      }
+      const fixed = localStorage.getItem(STORAGE_FIXED_KEY)
+      if (fixed !== null) {
+        try {
+          this.fixed = JSON.parse(fixed)
+        } catch {
+          this.fixed = false
+        }
       }
     },
     persist() {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(this.items))
+      localStorage.setItem(STORAGE_FIXED_KEY, JSON.stringify(this.fixed))
     },
   },
 })


### PR DESCRIPTION
## Summary
- add CartPanel component to display cart contents
- extend cart store with fixed/visible state
- show CartPanel in header with toggle button

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6862ffb16170832185e2b526075f8b14