### PR TITLE
Add orders page and dropdown

### DIFF
--- a/src/components/shared/CartPanel/index.vue
+++ b/src/components/shared/CartPanel/index.vue
@@ -26,15 +26,38 @@
         Fixo
       </label>
     </div>
+    <div class="dropdown mt-2" v-if="orders.orders.length">
+      <button class="btn btn-secondary dropdown-toggle w-100" type="button" @click="showOrders = !showOrders">
+        Pedidos
+      </button>
+      <div class="dropdown-menu w-100 p-2" :class="{ show: showOrders }">
+        <div v-for="o in orders.orders" :key="o.id" class="mb-2">
+          <details>
+            <summary>
+              <router-link :to="`/orders/${o.id}`">Pedido #{{ o.id }}</router-link>
+            </summary>
+            <ul class="list-unstyled ms-3">
+              <li v-for="i in o.items" :key="i.product.id">
+                {{ i.product.name }} (x{{ i.quantity }})
+              </li>
+            </ul>
+          </details>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import { useCartStore } from '@/stores/cart'
+import { useOrderStore } from '@/stores/order'
 
 const cart = useCartStore()
 cart.load()
+const orders = useOrderStore()
+orders.load()
+const showOrders = ref(false)
 
 const panelClasses = computed(() => [
   'cart-panel',

--- a/src/components/shared/SideBar/index.vue
+++ b/src/components/shared/SideBar/index.vue
@@ -3,6 +3,7 @@
     <ul class="list-unstyled p-2">
       <li><router-link to="/">Home</router-link></li>
       <li><router-link to="/about">Sobre</router-link></li>
+      <li><router-link to="/orders">Pedidos</router-link></li>
     </ul>
   </nav>
 </template>

--- a/src/pages/Order/index.ts
+++ b/src/pages/Order/index.ts
@@ -1,0 +1,1 @@
+// página de detalhes do pedido

--- a/src/pages/Order/index.vue
+++ b/src/pages/Order/index.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="container py-5" v-if="order">
+    <h1>Pedido #{{ order.id }}</h1>
+    <p class="text-muted">{{ formatDate(order.date) }}</p>
+    <ul class="list-group">
+      <li v-for="i in order.items" :key="i.product.id" class="list-group-item">
+        {{ i.product.name }} (x{{ i.quantity }})
+      </li>
+    </ul>
+  </div>
+  <div v-else class="container py-5">
+    <h1>Pedido não encontrado</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRoute } from 'vue-router'
+import { useOrderStore } from '@/stores/order'
+
+const orders = useOrderStore()
+const route = useRoute()
+const order = ref(orders.getOrder(Number(route.params.id)))
+
+onMounted(() => {
+  orders.load()
+  order.value = orders.getOrder(Number(route.params.id))
+})
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleString()
+}
+</script>
+
+<style scoped src="./styles.scss"></style>

--- a/src/pages/Order/styles.scss
+++ b/src/pages/Order/styles.scss
@@ -1,0 +1,1 @@
+/* estilos da página Order */

--- a/src/pages/Orders/index.ts
+++ b/src/pages/Orders/index.ts
@@ -1,0 +1,1 @@
+// funções da página Orders

--- a/src/pages/Orders/index.vue
+++ b/src/pages/Orders/index.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="container py-5">
+    <h1>Pedidos</h1>
+    <button class="btn btn-primary mb-3" :disabled="cart.items.length === 0" @click="createOrder">
+      Criar pedido
+    </button>
+    <div v-if="ordersStore.orders.length === 0">Nenhum pedido</div>
+    <ul class="list-group" v-else>
+      <li v-for="o in ordersStore.orders" :key="o.id" class="list-group-item">
+        <details>
+          <summary>
+            <router-link :to="`/orders/${o.id}`">Pedido #{{ o.id }}</router-link>
+            - {{ formatDate(o.date) }}
+          </summary>
+          <ul class="list-unstyled mt-2 ms-3">
+            <li v-for="i in o.items" :key="i.product.id">
+              {{ i.product.name }} (x{{ i.quantity }})
+            </li>
+          </ul>
+        </details>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import { useCartStore } from '@/stores/cart'
+import { useOrderStore } from '@/stores/order'
+
+const cart = useCartStore()
+const ordersStore = useOrderStore()
+
+onMounted(() => {
+  ordersStore.load()
+  cart.load()
+})
+
+function createOrder() {
+  if (cart.items.length === 0) return
+  ordersStore.addOrder(cart.items)
+  cart.items = []
+  cart.persist()
+}
+
+function formatDate(date: string) {
+  return new Date(date).toLocaleString()
+}
+</script>

--- a/src/pages/Orders/styles.scss
+++ b/src/pages/Orders/styles.scss
@@ -1,0 +1,1 @@
+/* estilos da página Orders */

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,6 +6,8 @@ const AboutPage = () => import('@/pages/About/index.vue')
 const FreightPage = () => import('@/pages/Freight/index.vue')
 const CartPage = () => import('@/pages/Cart/index.vue')
 const AdminPage = () => import('@/pages/Admin/index.vue')
+const OrdersPage = () => import('@/pages/Orders/index.vue')
+const OrderPage = () => import('@/pages/Order/index.vue')
 import { useAuthStore } from '@/stores/auth'
 
 const routes = [
@@ -15,6 +17,8 @@ const routes = [
   { path: '/about', name: 'about', component: AboutPage },
   { path: '/freight', name: 'freight', component: FreightPage },
   { path: '/cart', name: 'cart', component: CartPage, meta: { requiresAuth: true } },
+  { path: '/orders', name: 'orders', component: OrdersPage, meta: { requiresAuth: true } },
+  { path: '/orders/:id', name: 'order', component: OrderPage, meta: { requiresAuth: true } },
   { path: '/admin', name: 'admin', component: AdminPage, meta: { requiresAuth: true, roles: ['admin'] } },
   { path: '/:catchAll(.*)*', redirect: '/' },
 ]

--- a/src/stores/order.ts
+++ b/src/stores/order.ts
@@ -1,0 +1,44 @@
+import { defineStore } from 'pinia'
+import type { CartItem } from './cart'
+
+export interface Order {
+  id: number
+  items: CartItem[]
+  date: string
+}
+
+const STORAGE_KEY = 'orders'
+
+export const useOrderStore = defineStore('order', {
+  state: () => ({
+    orders: [] as Order[],
+  }),
+  actions: {
+    load() {
+      const data = localStorage.getItem(STORAGE_KEY)
+      if (data) {
+        try {
+          this.orders = JSON.parse(data)
+        } catch {
+          this.orders = []
+        }
+      }
+    },
+    persist() {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.orders))
+    },
+    addOrder(items: CartItem[]) {
+      const id = this.orders.length > 0 ? this.orders[this.orders.length - 1].id + 1 : 1
+      const order: Order = {
+        id,
+        items: JSON.parse(JSON.stringify(items)),
+        date: new Date().toISOString(),
+      }
+      this.orders.push(order)
+      this.persist()
+    },
+    getOrder(id: number) {
+      return this.orders.find((o) => o.id === id)
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add Orders page to create and list orders
- show orders dropdown inside cart panel
- add orders link in sidebar
- add orders store and router entry
- add page for individual orders

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68630b16f7588321a2406884e63b2311