### PR TITLE
Adjust to load products from CSV

### DIFF
--- a/public/data/produtos.csv
+++ b/public/data/produtos.csv
@@ -1,0 +1,11 @@
+id,name,price,image
+1,Arranhador de Gatos,59.90,https://placekitten.com/200/200?image=1
+2,Brinquedo Mordedor para Cães,29.90,https://placekitten.com/200/200?image=2
+3,Bolsa de Transporte para Pets,99.90,https://placekitten.com/200/200?image=3
+4,Casinha de Cachorro,149.90,https://placekitten.com/200/200?image=4
+5,Coleira LED Noturna,45.90,https://placekitten.com/200/200?image=5
+6,Bebedouro Automático,79.90,https://placekitten.com/200/200?image=6
+7,Cama Almofadada,89.90,https://placekitten.com/200/200?image=7
+8,Kit Higiene Pet,39.90,https://placekitten.com/200/200?image=8
+9,Porta Petiscos Interativo,55.90,https://placekitten.com/200/200?image=9
+10,Roupa Inverno para Pets,69.90,https://placekitten.com/200/200?image=10

--- a/src/pages/Home/index.vue
+++ b/src/pages/Home/index.vue
@@ -39,7 +39,7 @@ const displayed = computed(() => {
 })
 
 onMounted(() => {
-  loadProducts('/data/produtos.json')
+  loadProducts('/data/produtos.csv')
 })
 
 function add(p: Product) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -6,6 +6,8 @@ async function parseCSV(file: File | string): Promise<Product[]> {
   return new Promise((resolve) => {
     Papa.parse<Product>(file as any, {
       header: true,
+      download: typeof file === 'string',
+      skipEmptyLines: true,
       complete: (results) => resolve(results.data as Product[]),
     })
   })


### PR DESCRIPTION
## Summary
- update loader to fetch CSV files correctly
- load products from `produtos.csv`
- add sample `produtos.csv` dataset

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68631226f8288321b834b62a80d81807