### PR TITLE
Ajusta sidebar e carrinho responsivo

### DIFF
--- a/src/components/shared/CartPanel/index.vue
+++ b/src/components/shared/CartPanel/index.vue
@@ -1,5 +1,6 @@
 <template>
-  <div :class="panelClasses" v-show="cart.visible || cart.fixed">
+  <div v-if="cart.visible && !cart.fixed" class="cart-overlay" @click="cart.hide()" />
+  <div :class="panelClasses">
     <div class="cart-header d-flex justify-content-between align-items-center">
       <h5 class="mb-0">
         <i class="bi bi-cart3 me-2"></i>
@@ -165,11 +166,12 @@ const orders = useOrderStore()
 cart.load()
 orders.load()
 
-const panelClasses = computed(() => [
-  'cart-panel',
-  'shadow-lg',
-  cart.fixed ? 'position-fixed cart-fixed' : 'position-absolute',
-])
+const panelClasses = computed(() => ({
+  'cart-panel': true,
+  'shadow-lg': true,
+  show: cart.visible || cart.fixed,
+  'cart-fixed': cart.fixed,
+}))
 
 const recentOrders = computed(() => {
   return orders.orders.slice(-3).reverse() // Últimos 3 pedidos
@@ -212,22 +214,36 @@ function handleImageError(event: Event) {
 
 <style scoped>
 .cart-panel {
-  top: 100%;
-  right: 0;
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  right: -400px;
   width: 380px;
   max-width: 90vw;
   background: white;
   border: 1px solid #dee2e6;
-  border-radius: 8px;
   z-index: 1050;
-  max-height: 80vh;
   overflow-y: auto;
+  transition: right 0.3s ease;
+}
+
+.cart-panel.show {
+  right: 0;
 }
 
 .cart-fixed {
-  top: 20px;
-  right: 20px;
+  right: 0;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1) !important;
+}
+
+.cart-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1040;
 }
 
 .cart-header {
@@ -437,19 +453,8 @@ function handleImageError(event: Event) {
 /* Responsive */
 @media (max-width: 767.98px) {
   .cart-panel {
-    width: 100vw;
-    left: 0;
-    right: 0;
+    width: 100%;
     border-radius: 0;
-    max-height: 70vh;
-  }
-  
-  .cart-fixed {
-    top: 10px;
-    left: 10px;
-    right: 10px;
-    width: auto;
-    border-radius: 8px;
   }
 }
 </style>

--- a/src/components/shared/SideBar/index.vue
+++ b/src/components/shared/SideBar/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav :class="sidebarClasses">
+  <nav :class="sidebarClasses" @mouseenter="expandSidebar" @mouseleave="collapseSidebar">
     <!-- Toggle button for mobile -->
     <button 
       class="sidebar-toggle d-md-none"
@@ -69,16 +69,25 @@ import { useRouter } from 'vue-router';
 
 const authStore = useAuthStore();
 const router = useRouter();
-const isExpanded = ref(false);
+const isExpanded = ref(false)
 
 const sidebarClasses = computed(() => ({
-  'sidebar': true,
-  'sidebar-expanded': isExpanded.value
-}));
+  sidebar: true,
+  'sidebar-expanded': isExpanded.value,
+  'sidebar-collapsed': !isExpanded.value,
+}))
 
 const toggleSidebar = () => {
   isExpanded.value = !isExpanded.value;
 };
+
+const expandSidebar = () => {
+  isExpanded.value = true
+}
+
+const collapseSidebar = () => {
+  isExpanded.value = false
+}
 
 const closeSidebar = () => {
   isExpanded.value = false;
@@ -106,6 +115,21 @@ const handleLogout = async () => {
   top: 0;
   overflow-y: auto;
   transition: transform 0.3s ease;
+}
+
+.sidebar-collapsed {
+  width: 60px;
+}
+
+.sidebar-collapsed .sidebar-title,
+.sidebar-collapsed .nav-link span {
+  display: none;
+}
+
+.sidebar-collapsed .nav-link {
+  justify-content: center;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
 }
 
 .sidebar-toggle {
@@ -277,15 +301,15 @@ const handleLogout = async () => {
     transform: translateX(0) !important;
   }
 
-  .sidebar.d-none {
-    display: flex !important;
+  .sidebar-collapsed {
+    width: 250px;
   }
 }
 
-/* Desktop adjustments */
 @media (min-width: 768px) {
   .sidebar {
-    position: relative;
+    position: sticky;
+    top: 0;
     transform: none !important;
   }
 

--- a/src/pages/Home/index.vue
+++ b/src/pages/Home/index.vue
@@ -154,7 +154,6 @@
             <option :value="10">10</option>
             <option :value="20">20</option>
             <option :value="30">30</option>
-            <option :value="50">50</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- expand/collapse sidebar ao passar o mouse ou tocar no mobile
- transforma o carrinho em painel lateral com overlay
- remove opção de 50 itens por página

## Testing
- `npm test`
- `npm run lint` *(falhou: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6863527f90588321ada3ff02c35de743